### PR TITLE
Publicação de documentação em site

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-      - uses: actions/checkout@v4
+        uses: actions/checkout@v4
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -1,0 +1,42 @@
+name: Deploy Doxygen-generated docs
+on:
+  push:
+    branches: [docs]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+      - uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Generate Doxygen
+        run: |
+          sudo apt-get install -y doxygen graphviz
+          doxygen docs/config
+
+      - name: Upload output
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: 'docs/html'
+      
+      - name: Deploy to Github Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+        

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .vscode
 *.out
-docs/out
+docs/html
 cjavap
 build
 .idea

--- a/docs/config
+++ b/docs/config
@@ -9,7 +9,7 @@ PROJECT_NUMBER         =
 PROJECT_BRIEF          =
 PROJECT_LOGO           =
 PROJECT_ICON           =
-OUTPUT_DIRECTORY       = docs/out
+OUTPUT_DIRECTORY       = docs
 CREATE_SUBDIRS         = YES
 CREATE_SUBDIRS_LEVEL   = 8
 ALLOW_UNICODE_NAMES    = NO
@@ -292,7 +292,7 @@ EXTRA_SEARCH_MAPPINGS  =
 #---------------------------------------------------------------------------
 # Configuration options related to the LaTeX output
 #---------------------------------------------------------------------------
-GENERATE_LATEX         = YES
+GENERATE_LATEX         = NO
 LATEX_OUTPUT           = latex
 LATEX_CMD_NAME         =
 MAKEINDEX_CMD_NAME     = makeindex


### PR DESCRIPTION
Após alguns últimos ajustes na configuração do Doxygen, foi criado um _workflow_ para _deploy_ da documentação no Github Pages. Qualquer _push_ na _branch_ `docs` dispara o _deploy_, então essa _branch_ deve ser preservada.
O site com a documentação está disponível em https://gscolombo.github.io/Leitor-Exibidor-de-bytecode-Java/.