### PR TITLE
Leitura ignorada de atributos opcionais

### DIFF
--- a/src/reader.c
+++ b/src/reader.c
@@ -187,11 +187,8 @@ void read_attributes(const cp_info *cp, u2 n, FILE *fptr, attribute *attr)
                             read_attributes(cp, c, fptr, attr[i].info.Code.attributes);
                     }
                     break;
-                case LineNumberTable:
-                    c = read_u2(fptr);
-                    fseek(fptr, c * sizeof(struct line_number_table), SEEK_CUR);
-                    break;
                 default:
+                    fseek(fptr, attr[i].attribute_length, SEEK_CUR);
                     break;
                 }
         }


### PR DESCRIPTION
Para não considerar quaisquer atributos opcionais ou que não serão implementados (agora) nesse projeto, somente incluí como padrão mover o ponteiro o número de _bytes_ associado às informações do atributo na função `read_attributes`.