### PR TITLE
Correção de função para exibição de constantes.

### DIFF
--- a/src/cp/writer.c
+++ b/src/cp/writer.c
@@ -14,9 +14,9 @@ void show_constants(u2 count, cp_info *_cp)
         switch (cp->tag)
         {
         case CONSTANT_Class:
-            u2 cls_name_index = cp->info.Class.name_index - i;
+            u2 cls_name_index = cp->info.Class.name_index;
             printf("%s#%u = Class\t\t\t#%u\t\t// %ls\n",
-                   pad, i, cls_name_index, cp[cls_name_index].info.UTF8.str);
+                   pad, i, cls_name_index, _cp[cls_name_index - 1].info.UTF8.str);
             break;
         case CONSTANT_Fieldref:
         case CONSTANT_Methodref:
@@ -34,9 +34,9 @@ void show_constants(u2 count, cp_info *_cp)
             u2 name_and_type_index = cp->info.Ref.name_and_type_index;
 
             // Recuperação as strings para exibição
-            wchar_t *cls = cp[cp[cls_index - i].info.Class.name_index - i].info.UTF8.str;
-            wchar_t *ref_name = cp[cp[name_and_type_index - i].info.NameAndType.name_index - i].info.UTF8.str;
-            wchar_t *ref_type = cp[cp[name_and_type_index - i].info.NameAndType.descriptor_index - i].info.UTF8.str;
+            wchar_t *cls = _cp[_cp[cls_index - 1].info.Class.name_index - 1].info.UTF8.str;
+            wchar_t *ref_name = _cp[_cp[name_and_type_index - 1].info.NameAndType.name_index - 1].info.UTF8.str;
+            wchar_t *ref_type = _cp[_cp[name_and_type_index - 1].info.NameAndType.descriptor_index - 1].info.UTF8.str;
 
             // Inclusão de aspas na função <init> para conformidade com saída do javap
             ref_name = !wcscmp(ref_name, (wchar_t *)L"<init>") ? L"\"<init>\"" : ref_name;
@@ -46,7 +46,7 @@ void show_constants(u2 count, cp_info *_cp)
             break;
         case CONSTANT_String:
             u2 str_index = cp->info.String.string_index;
-            printf("%s#%u = String\t\t\t#%u\t\t// %ls\n", pad, i, str_index, cp[str_index - i].info.UTF8.str);
+            printf("%s#%u = String\t\t\t#%u\t\t// %ls\n", pad, i, str_index, _cp[str_index - 1].info.UTF8.str);
             break;
         case CONSTANT_Integer:
             printf("%s#%u = Integer\t\t\t%i\n", pad, i, cp->info._4Bn.number.i);
@@ -66,8 +66,8 @@ void show_constants(u2 count, cp_info *_cp)
             u2 desc_index = cp->info.NameAndType.descriptor_index;
 
             // Recuperação das strings
-            wchar_t *name = cp[name_index - i].info.UTF8.str;
-            wchar_t *desc = cp[desc_index - i].info.UTF8.str;
+            wchar_t *name = _cp[name_index - 1].info.UTF8.str;
+            wchar_t *desc = _cp[desc_index - 1].info.UTF8.str;
 
             // Inclusão de aspas no método <init> para conformidade com saída do javap
             name = !wcscmp(name, (wchar_t *)L"<init>") ? L"\"<init>\"" : name;


### PR DESCRIPTION
A função `show_constants` foi corrigida e agora utiliza o ponteiro para o _pool_ de constantes passado como parâmetro ao invés da cópia incrementada no _loop_. Assim, o erro de acesso à memória que ocorria para alguns arquivos `.class` foi resolvido.