### PR TITLE
Troca de wchar_t por char

### DIFF
--- a/docs/config
+++ b/docs/config
@@ -62,18 +62,18 @@ GROUP_NESTED_COMPOUNDS = YES
 SUBGROUPING            = YES
 INLINE_GROUPED_CLASSES = NO
 INLINE_SIMPLE_STRUCTS  = NO
-TYPEDEF_HIDES_STRUCT   = NO
+TYPEDEF_HIDES_STRUCT   = YES
 LOOKUP_CACHE_SIZE      = 0
 NUM_PROC_THREADS       = 1
 TIMESTAMP              = NO
 #---------------------------------------------------------------------------
 # Build related configuration options
 #---------------------------------------------------------------------------
-EXTRACT_ALL            = YES
+EXTRACT_ALL            = NO
 EXTRACT_PRIVATE        = NO
 EXTRACT_PRIV_VIRTUAL   = NO
 EXTRACT_PACKAGE        = NO
-EXTRACT_STATIC         = NO
+EXTRACT_STATIC         = YES
 EXTRACT_LOCAL_CLASSES  = NO
 EXTRACT_LOCAL_METHODS  = NO
 EXTRACT_ANON_NSPACES   = NO
@@ -361,7 +361,7 @@ PERLMOD_MAKEVAR_PREFIX =
 # Configuration options related to the preprocessor
 #---------------------------------------------------------------------------
 ENABLE_PREPROCESSING   = YES
-MACRO_EXPANSION        = NO
+MACRO_EXPANSION        = YES
 EXPAND_ONLY_PREDEF     = NO
 SEARCH_INCLUDES        = YES
 INCLUDE_PATH           = 

--- a/include/Classfile.h
+++ b/include/Classfile.h
@@ -8,6 +8,8 @@
 #include "constants.h"
 #include "utils.h"
 
+/** @file */
+
 /**
  * @brief Estrutura que representa um arquivo .class Java, conforme especificação JVM 8.
  */

--- a/include/cp/parser.h
+++ b/include/cp/parser.h
@@ -7,8 +7,16 @@
 
 #include "constants.h"
 
+/** @file parser.h
+ *  @brief Funções para leitura do _pool_ de constantes e decodificação de _bytes_ de constantes.
+ */
+
 /**
  * @brief Lê as constantes do pool de constantes em um arquivo .class.
+ * 
+ * Após alocar espaço na memória para um _array_ de estruturas `cp_info` com base na quantidade `count` de constantes,
+ * o _byte_ correspondente a _tag_ para cada constante é lido e utilizado para ler o restante das 
+ * informações do tipo de constante correspondente.
  * 
  * @param fptr Ponteiro para um arquivo .class.
  * @param count Número de constantes no pool de constantes.
@@ -20,19 +28,23 @@ cp_info* parse_constant_pool(FILE*, u2);
 /**
  * @brief Decodifica uma sequência de bytes no formato UTF-8 modificado.
  * 
+ * São realizadas duas passagens pela sequência de _bytes_: a primeira para definir o tamanho da _string_ final
+ * e a segunda para decodificar os _code points_ no formato UTF-8 modificado, com base na especificação da JVM 8.
+ * Para melhor compatibilidade, é utilizado o tipo de caractere extendido `char` para compor a _string_ final.
+ * 
  * @param length Quantidade de bytes da string.
  * @param bytes Array de bytes.
  * 
  * @return String no formato UTF-8 modificado correspondente ao array de bytes.
  */
-wchar_t* decode_modified_utf8_str(u2, const u1*);
+char* decode_modified_utf8_str(u2, const u1*);
 
 /**
  * @brief Decodifica uma sequência de bytes correspondente a um valor do tipo float.
  * 
  * @param b Array de bytes.
  * 
- * @return Float correspondente à sequência de bytes.
+ * @return `float` correspondente à sequência de bytes.
  */
 float decode_float_bytes(u4);
 
@@ -41,7 +53,7 @@ float decode_float_bytes(u4);
  * 
  * @param b Array de bytes.
  * 
- * @return Long correspondente à sequência de bytes.
+ * @return `long` correspondente à sequência de bytes.
  */
 long decode_long_bytes(u4, u4);
 
@@ -50,7 +62,7 @@ long decode_long_bytes(u4, u4);
  * 
  * @param b Array de bytes.
  * 
- * @return Long correspondente à sequência de bytes.
+ * @return `double` correspondente à sequência de bytes.
  */
 double decode_double_bytes(u4, u4);
 

--- a/include/cp/writer.h
+++ b/include/cp/writer.h
@@ -10,10 +10,18 @@
 #include "utils.h"
 #include "wchar.h"
 
+/** @file
+ *  @brief Funções para exibição formatada das constantes no _pool_ de constantes.
+ */
+
 /**
  * @brief Exibe as constantes do pool de constantes.
  *
  * Esta função recupera e exibe as constante do pool de constantes.
+ * 
+ * O formato de exibição é similar ao retornado pela ferramenta `javap` com _flag_ `-v`.
+ * Para cada constante no _pool_, é realizada a leitura da _tag_ e, com base no tipo da constante, as informações
+ * específicas são recuperadas, formatadas e apresentadas no terminal.
  *
  * @param count O número de constantes no pool de constantes.
  * @param _cp Um ponteiro para o array do pool de constantes.

--- a/include/members/fields.h
+++ b/include/members/fields.h
@@ -11,6 +11,8 @@
 #include "utils.h"
 #include "wchar.h"
 
+/** @file */
+
 /**
  * Exibe os campos (fields) de uma estrutura ClassFile.
  *

--- a/include/members/methods.h
+++ b/include/members/methods.h
@@ -11,6 +11,8 @@
 #include "utils.h"
 #include "wchar.h"
 
+/** @file */
+
 /**
  * Exibe os métodos de uma estrutura ClassFile.
  *

--- a/include/reader.h
+++ b/include/reader.h
@@ -14,6 +14,8 @@
 
 #define LE (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__ ? 1 : 0)
 
+/** @file */
+
 /**
  * @brief Abre e retorna um ponteiro para um arquivo .class.
  * 

--- a/include/types/attributes/attribute_enum.h
+++ b/include/types/attributes/attribute_enum.h
@@ -1,7 +1,9 @@
 #ifndef TYPES_ATTRIBUTES_ATTRIBUTE_ENUM_H
 #define TYPES_ATTRIBUTES_ATTRIBUTE_ENUM_H
 
-// Enumeração de nomes de atributos para uso em funções utilitárias
+/** @file */
+
+/// @brief Enumeração de nomes de atributos para uso em funções utilitárias
 typedef enum
 {
     ConstantValue,

--- a/include/types/attributes/attribute_info.h
+++ b/include/types/attributes/attribute_info.h
@@ -1,7 +1,6 @@
 #ifndef TYPES_ATTRIBUTES_ATTRIBUTE_INFO_H
 #define TYPES_ATTRIBUTES_ATTRIBUTE_INFO_H
 
-#include <wchar.h>
 
 #include "uinteger.h"
 #include "attributes.h"
@@ -19,6 +18,30 @@ typedef struct attribute
 
     /// @brief Informações específicas do tipo de atributo.
     /// @see attribute_info para estruturas específicas por tipo.
+    /**
+     * @note
+     * @parblock
+     * Alguns atributos necessários para suporte a debugging e novos mecanismos da JVM 8, estão fora do escopo deste projeto 
+     * e não serão implementados.\n
+     * Contudo, suas estruturas básicas foram definidas para fins de documentação e facilitar uma eventual implementação futura.
+     * 
+     * Os atributos **não** considerados são:
+     * - AnnotationDefault
+     * - LineNumberTable
+     * - LocalVariableTable
+     * - LocalVariableTypeTable
+     * - Deprecated
+     * - SourceDebugExtension
+     * - Signature
+     * - RuntimeVisibleAnnotations
+     * - RuntimeInvisibleAnnotations
+     * - RuntimeVisibleParameterAnnotations
+     * - RuntimeInvisibleParameterAnnotations
+     * - EnclosingMethod
+     * - BootstrapMethods
+     * - MethodParameters
+     * @endparblock
+     */
     attribute_info info;
 } attribute;
 

--- a/include/types/attributes/attributes.h
+++ b/include/types/attributes/attributes.h
@@ -50,9 +50,9 @@ typedef union attribute_info
         /// @brief Número de entradas na tabela de stack map frames
         u2 number_of_entries;
         /// @brief Array de stack map frames que definem o estado da pilha em pontos específicos do código
-        union stack_map_frame
+        /// @note Deve ser finalizado caso seja implementado o mecanismo de verificação de tipo especificado para a JVM 8.
+        struct stack_map_frame
         {
-            // Stack map frame types would be defined here
         } *entries;
     } StackMapTable;
 
@@ -177,9 +177,9 @@ typedef union attribute_info
         /// @brief Número de anotações definidas
         u2 num_annotations;
         /// @brief Array de estruturas de anotações
+        /// @note Deve ser finalizado caso a JVM necessite executar programas Java com anotações.
         struct annotation
         {
-            // Annotation structure would be defined here
         } *annotations;
     } RuntimeVisibleAnnotations, RuntimeInvisibleAnnotations;
 
@@ -202,9 +202,9 @@ typedef union attribute_info
     struct AnnotationDefault
     {
         /// @brief Valor padrão da anotação quando não explicitamente especificado
+        /// @note Faz parte da estrutura `annotation`, de acordo com a especificação da JVM 8.
         struct element_value
         {
-            // Element value structure would be defined here
         } default_value;
     } AnnotationDefault;
 

--- a/include/types/cp/constants.h
+++ b/include/types/cp/constants.h
@@ -19,6 +19,8 @@
 
 #include "uinteger.h"
 
+/** @file */
+
 /**
  * União dos diferentes
  * tipos de constantes apresentados
@@ -95,7 +97,7 @@ typedef union Constant
         /// @brief Bytes da _string_ constante.
         u1 *bytes;
         /// @brief _String_ decodificada do formato UTF-8 modificado
-        wchar_t *str;
+        char *str;
     } UTF8;
 
     /// @brief Representa um manipulador de método.

--- a/include/types/member.h
+++ b/include/types/member.h
@@ -4,6 +4,8 @@
 #include "uinteger.h"
 #include "attribute_info.h"
 
+/** @file */
+
 /**
  * @brief Mapeia um valor de flag para seu nome em string.
  */

--- a/include/types/uinteger.h
+++ b/include/types/uinteger.h
@@ -3,13 +3,17 @@
 
 #include <stdint.h>
 
+/** @file */
+
 /**
+ * @typedef u1
  * @brief Inteiro não negativo de 1 byte.
  * @details Usado para representar bytes individuais, opcodes, e pequenos valores numéricos.
  */
 typedef uint8_t u1;
 
 /**
+ * @typedef u2
  * @brief Inteiro não negativo de 2 bytes.
  * @details Usado para índices de constant pool, contagens, e valores de 16 bits.
  */

--- a/include/utils.h
+++ b/include/utils.h
@@ -9,6 +9,8 @@
 #include "attribute_enum.h"
 #include "member.h"
 
+/** @file */
+
 /**
  * @brief Troca os dois bytes de um inteiro de 16 bits.
  *
@@ -62,7 +64,7 @@ char *parse_flags(u2, size_t, const char *, const FlagMap[]);
  * @param name Nome do atributo.
  * @return Valor enumerado correspondente ao nome do atributo.
  */
-const attribute_name *convert_attr_name(const wchar_t *);
+const attribute_name *convert_attr_name(const char *);
 
 /**
  * @brief Converte um descritor na sua versão intelígivel (original),
@@ -72,6 +74,6 @@ const attribute_name *convert_attr_name(const wchar_t *);
  * @param sep String a ser utilizada como separador entre cada símbolo do descritor.
  * @return String com a versão intelígivel do descritor.
  */
-wchar_t *parse_descriptor(const wchar_t *, wchar_t *);
+char *parse_descriptor(const char *, char *);
 
 #endif

--- a/include/writer.h
+++ b/include/writer.h
@@ -4,7 +4,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
-#include <wchar.h>
 
 #include "Classfile.h"
 #include "member.h"
@@ -12,6 +11,8 @@
 #include "cp/writer.h"
 #include "methods.h"
 #include "fields.h"
+
+/** @file */
 
 /**
  * @brief Exibe as informações de um `ClassFile`.

--- a/src/cp/parser.c
+++ b/src/cp/parser.c
@@ -83,10 +83,10 @@ cp_info *parse_constant_pool(FILE *fptr, u2 count)
         cp++;
     }
 
-    return cp - (count - 1);
+    return constant_pool;
 }
 
-wchar_t *decode_modified_utf8_str(u2 length, const u1 *bytes)
+char *decode_modified_utf8_str(u2 length, const u1 *bytes)
 {
     if (bytes == NULL)
     {
@@ -100,23 +100,19 @@ wchar_t *decode_modified_utf8_str(u2 length, const u1 *bytes)
     {
         u1 x = bytes[pos];
 
-        if (x < 0x80)
+        if (x < 0x80) // 1 byte code point
         {
             buffer_size++;
             pos++;
-
-            // 2 byte code point
         }
-        else if ((x & 0xE0) == 0xC0)
+        else if ((x & 0xE0) == 0xC0) // 2 bytes code point
         { // Check if high byte starts with 110
             if (pos + 1 >= length)
                 return NULL; // Early return if truncated sequence
             buffer_size++;
             pos += 2;
-
-            // 3 byte code point
         }
-        else if ((x & 0xF0) == 0xE0)
+        else if ((x & 0xF0) == 0xE0) // 3 bytes code point
         { // Check if high byte starts with 1110
             if (pos + 2 >= length)
                 return NULL; // Same as above
@@ -129,7 +125,7 @@ wchar_t *decode_modified_utf8_str(u2 length, const u1 *bytes)
         }
     }
 
-    wchar_t *str = (wchar_t *)malloc((buffer_size + 1) * sizeof(wchar_t));
+    char *str = (char *)malloc((buffer_size + 1) * sizeof(char));
     if (str == NULL)
         return NULL;
 
@@ -142,14 +138,14 @@ wchar_t *decode_modified_utf8_str(u2 length, const u1 *bytes)
 
         if (x < 0x80)
         {
-            str[i++] = (wchar_t)x;
+            str[i++] = (char)x;
             pos++;
         }
         else if ((x & 0xE0) == 0xC0)
         {
             u1 y = bytes[pos + 1];
             u2 code_point = ((x & 0x1F) << 6) | (y & 0x3F);
-            str[i++] = code_point == 0 ? L'\0' : (wchar_t)code_point; // The null character is represent by two bytes (0xC0,0x80);
+            str[i++] = code_point == 0 ? L'\0' : (char)code_point; // The null character is represented by two bytes (0xC0,0x80);
             pos += 2;
         }
         else if ((x & 0xF0) == 0xE0)
@@ -157,7 +153,7 @@ wchar_t *decode_modified_utf8_str(u2 length, const u1 *bytes)
             u1 y = bytes[pos + 1];
             u1 z = bytes[pos + 2];
             u2 code_point = ((x & 0xF) << 12) | ((y & 0x3F) << 6) | (z & 0x3F);
-            str[i++] = (wchar_t)code_point;
+            str[i++] = (char)code_point;
             pos += 3;
         }
     }

--- a/src/cp/writer.c
+++ b/src/cp/writer.c
@@ -15,7 +15,7 @@ void show_constants(u2 count, cp_info *_cp)
         {
         case CONSTANT_Class:
             u2 cls_name_index = cp->info.Class.name_index;
-            printf("%s#%u = Class\t\t\t#%u\t\t// %ls\n",
+            printf("%s#%u = Class\t\t\t#%u\t\t// %s\n",
                    pad, i, cls_name_index, _cp[cls_name_index - 1].info.UTF8.str);
             break;
         case CONSTANT_Fieldref:
@@ -34,19 +34,19 @@ void show_constants(u2 count, cp_info *_cp)
             u2 name_and_type_index = cp->info.Ref.name_and_type_index;
 
             // Recuperação as strings para exibição
-            wchar_t *cls = _cp[_cp[cls_index - 1].info.Class.name_index - 1].info.UTF8.str;
-            wchar_t *ref_name = _cp[_cp[name_and_type_index - 1].info.NameAndType.name_index - 1].info.UTF8.str;
-            wchar_t *ref_type = _cp[_cp[name_and_type_index - 1].info.NameAndType.descriptor_index - 1].info.UTF8.str;
+            char *cls = _cp[_cp[cls_index - 1].info.Class.name_index - 1].info.UTF8.str;
+            char *ref_name = _cp[_cp[name_and_type_index - 1].info.NameAndType.name_index - 1].info.UTF8.str;
+            char *ref_type = _cp[_cp[name_and_type_index - 1].info.NameAndType.descriptor_index - 1].info.UTF8.str;
 
             // Inclusão de aspas na função <init> para conformidade com saída do javap
-            ref_name = !wcscmp(ref_name, (wchar_t *)L"<init>") ? L"\"<init>\"" : ref_name;
+            ref_name = !strcmp(ref_name, (char *)"<init>") ? "\"<init>\"" : ref_name;
 
-            printf("%s#%u = %s\t\t\t#%u.#%u\t\t// %ls.%ls:%ls\n",
+            printf("%s#%u = %s\t\t\t#%u.#%u\t\t// %s.%s:%s\n",
                    pad, i, ref, cls_index, name_and_type_index, cls, ref_name, ref_type);
             break;
         case CONSTANT_String:
             u2 str_index = cp->info.String.string_index;
-            printf("%s#%u = String\t\t\t#%u\t\t// %ls\n", pad, i, str_index, _cp[str_index - 1].info.UTF8.str);
+            printf("%s#%u = String\t\t\t#%u\t\t// %s\n", pad, i, str_index, _cp[str_index - 1].info.UTF8.str);
             break;
         case CONSTANT_Integer:
             printf("%s#%u = Integer\t\t\t%i\n", pad, i, cp->info._4Bn.number.i);
@@ -66,16 +66,16 @@ void show_constants(u2 count, cp_info *_cp)
             u2 desc_index = cp->info.NameAndType.descriptor_index;
 
             // Recuperação das strings
-            wchar_t *name = _cp[name_index - 1].info.UTF8.str;
-            wchar_t *desc = _cp[desc_index - 1].info.UTF8.str;
+            char *name = _cp[name_index - 1].info.UTF8.str;
+            char *desc = _cp[desc_index - 1].info.UTF8.str;
 
             // Inclusão de aspas no método <init> para conformidade com saída do javap
-            name = !wcscmp(name, (wchar_t *)L"<init>") ? L"\"<init>\"" : name;
+            name = !strcmp(name, (char *)"<init>") ? "\"<init>\"" : name;
 
-            printf("%s#%u = NameAndType\t\t#%u.#%u\t\t// %ls:%ls\n", pad, i, name_index, desc_index, name, desc);
+            printf("%s#%u = NameAndType\t\t#%u.#%u\t\t// %s:%s\n", pad, i, name_index, desc_index, name, desc);
             break;
         case CONSTANT_UTF8:
-            printf("%s#%u = UTF-8\t\t\t%ls\n", pad, i, cp->info.UTF8.str);
+            printf("%s#%u = UTF-8\t\t\t%s\n", pad, i, cp->info.UTF8.str);
             break;
         case CONSTANT_MethodHandle:
             printf("%s#%u = MethodHandle\n", pad, i);

--- a/src/members/fields.c
+++ b/src/members/fields.c
@@ -36,15 +36,15 @@ void show_fields(const ClassFile *cf)
             member_info field = cf->fields[i];
 
             u2 access_flags = field.access_flags;
-            wchar_t *field_name = cp[field.name_index - 1].info.UTF8.str;
-            wchar_t *field_desc = cp[field.descriptor_index - 1].info.UTF8.str;
+            char *field_name = cp[field.name_index - 1].info.UTF8.str;
+            char *field_desc = cp[field.descriptor_index - 1].info.UTF8.str;
 
-            wchar_t *field_desc_str = parse_descriptor(field_desc, NULL);
+            char *field_desc_str = parse_descriptor(field_desc, NULL);
 
             char *flags = parse_flags(access_flags, 9, ", ", flag_map);
             char *kws = parse_flags(access_flags, 7, " ", flag_kw_map);
 
-            printf(" %s %ls%ls;\n    descriptor: %ls\n    flags: (0x%04x) %s\n%c",
+            printf(" %s %s%s;\n    descriptor: %s\n    flags: (0x%04x) %s\n%c",
                    kws, field_desc_str, field_name, field_desc,
                    access_flags, flags, nl);
 

--- a/src/members/methods.c
+++ b/src/members/methods.c
@@ -41,16 +41,16 @@ void show_methods(const ClassFile *cf)
             member_info method = cf->methods[i];
 
             u2 access_flags = method.access_flags;
-            wchar_t *method_name = cp[method.name_index - 1].info.UTF8.str;
-            wchar_t *method_desc = cp[method.descriptor_index - 1].info.UTF8.str;
+            char *method_name = cp[method.name_index - 1].info.UTF8.str;
+            char *method_desc = cp[method.descriptor_index - 1].info.UTF8.str;
 
             // Handle <init> method
-            int is_init = !wcscmp(method_name, L"<init>");
+            int is_init = !strcmp(method_name, "<init>");
             if (is_init)
             {
-                wchar_t *classname = cp[cp[cf->this_class - 1].info.Class.name_index - 1].info.UTF8.str;
+                char *classname = cp[cp[cf->this_class - 1].info.Class.name_index - 1].info.UTF8.str;
 
-                for (wchar_t *wcptr = classname; wcptr < classname + wcslen(classname) - 1; wcptr++)
+                for (char *wcptr = classname; wcptr < classname + strlen(classname) - 1; wcptr++)
                     if (*wcptr == L'/')
                     {
                         *wcptr = L'.';
@@ -61,40 +61,40 @@ void show_methods(const ClassFile *cf)
             }
 
             // Get parameters descriptor length
-            wchar_t *params_end = wcschr(method_desc, L')') + 1;
+            char *params_end = strchr(method_desc, L')') + 1;
 
             size_t params_desc_len = params_end - method_desc;
-            size_t ret_desc_len = wcslen(params_end);
+            size_t ret_desc_len = strlen(params_end);
 
             // Split descriptor
-            wchar_t *params_desc = (wchar_t *)calloc(params_desc_len + 1, sizeof(wchar_t));
+            char *params_desc = (char *)calloc(params_desc_len + 1, sizeof(char));
             if (params_desc)
             {
-                wcsncpy(params_desc, method_desc, params_desc_len);
+                strncpy(params_desc, method_desc, params_desc_len);
                 params_desc[params_desc_len] = L'\0';
             }
 
-            wchar_t *ret_desc = (wchar_t *)calloc(ret_desc_len + 1, sizeof(wchar_t));
+            char *ret_desc = (char *)calloc(ret_desc_len + 1, sizeof(char));
             if (ret_desc)
             {
-                wcsncpy(ret_desc, params_end, ret_desc_len);
+                strncpy(ret_desc, params_end, ret_desc_len);
                 ret_desc[ret_desc_len] = L'\0';
             }
 
             // Parse descriptors
-            wchar_t *params_str = NULL, *ret_str = NULL;
+            char *params_str = NULL, *ret_str = NULL;
 
             if (!is_init)
                 ret_str = parse_descriptor(ret_desc, NULL);
 
-            params_str = parse_descriptor(params_desc, L",");
+            params_str = parse_descriptor(params_desc, ",");
 
             // Parse flags
             char *flags = parse_flags(access_flags, 12, ", ", flag_map);
             char *kws = parse_flags(access_flags, 9, " ", flag_kw_map);
 
-            printf(" %s %ls%ls%ls;\n    descriptor: %ls\n    flags: (0x%04x) %s\n%c",
-                   kws, ret_str ? ret_str : L"", method_name, params_str, method_desc, access_flags, flags, nl);
+            printf(" %s %s%s%s;\n    descriptor: %s\n    flags: (0x%04x) %s\n%c",
+                   kws, ret_str ? ret_str : "", method_name, params_str, method_desc, access_flags, flags, nl);
 
             free(flags), free(kws);
             free(params_desc), free(ret_desc);

--- a/src/reader.c
+++ b/src/reader.c
@@ -138,7 +138,7 @@ void read_attributes(const cp_info *cp, u2 n, FILE *fptr, attribute *attr)
             attr[i].attribute_name_index = read_u2(fptr);
             attr[i].attribute_length = read_u4(fptr);
 
-            const wchar_t *attr_name = cp[attr[i].attribute_name_index - 1].info.UTF8.str;
+            const char *attr_name = cp[attr[i].attribute_name_index - 1].info.UTF8.str;
 
             const attribute_name *attr_type = convert_attr_name(attr_name);
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -83,36 +83,36 @@ char *parse_flags(u2 flags, size_t n, const char *sep, const FlagMap flag_map[])
 static const struct
 {
     const attribute_name attr;
-    const wchar_t *str;
+    const char *str;
 } conversion[] = {
-    {ConstantValue, L"ConstantValue"},
-    {Code, L"Code"},
-    {StackMapTable, L"StackMapTable"},
-    {Exceptions, L"Exceptions"},
-    {InnerClasses, L"InnerClasses"},
-    {EnclosingMethod, L"EnclosingMethod"},
-    {Synthetic, L"Synthetic"},
-    {Signature, L"Signature"},
-    {SourceFile, L"SourceFile"},
-    {SourceDebugExtension, L"SourceDebugExtension"},
-    {LineNumberTable, L"LineNumberTable"},
-    {LocalVariableTable, L"LocalVariableTable"},
-    {LocalVariableTypeTable, L"LocalVariableTypeTable"},
-    {Deprecated, L"Deprecated"},
-    {RuntimeVisibleAnnotations, L"RuntimeVisibleAnnotations"},
-    {RuntimeInvisibleAnnotations, L"RuntimeInvisibleAnnotations"},
-    {RuntimeVisibleParameterAnnotations, L"RuntimeVisibleParameterAnnotations"},
-    {RuntimeInvisibleParameterAnnotations, L"RuntimeInvisibleParameterAnnotations"},
-    {AnnotationDefault, L"AnnotationDefault"},
-    {BootstrapMethods, L"BootstrapMethods"},
-    {MethodParameters, L"MethodParameters"}};
+    {ConstantValue, "ConstantValue"},
+    {Code, "Code"},
+    {StackMapTable, "StackMapTable"},
+    {Exceptions, "Exceptions"},
+    {InnerClasses, "InnerClasses"},
+    {EnclosingMethod, "EnclosingMethod"},
+    {Synthetic, "Synthetic"},
+    {Signature, "Signature"},
+    {SourceFile, "SourceFile"},
+    {SourceDebugExtension, "SourceDebugExtension"},
+    {LineNumberTable, "LineNumberTable"},
+    {LocalVariableTable, "LocalVariableTable"},
+    {LocalVariableTypeTable, "LocalVariableTypeTable"},
+    {Deprecated, "Deprecated"},
+    {RuntimeVisibleAnnotations, "RuntimeVisibleAnnotations"},
+    {RuntimeInvisibleAnnotations, "RuntimeInvisibleAnnotations"},
+    {RuntimeVisibleParameterAnnotations, "RuntimeVisibleParameterAnnotations"},
+    {RuntimeInvisibleParameterAnnotations, "RuntimeInvisibleParameterAnnotations"},
+    {AnnotationDefault, "AnnotationDefault"},
+    {BootstrapMethods, "BootstrapMethods"},
+    {MethodParameters, "MethodParameters"}};
 
-const attribute_name *convert_attr_name(const wchar_t *name)
+const attribute_name *convert_attr_name(const char *name)
 {
     if (name != NULL)
         for (size_t i = 0; i < sizeof(conversion) / sizeof(conversion[0]); i++)
         {
-            if (!wcscmp(name, conversion[i].str))
+            if (!strcmp(name, conversion[i].str))
                 return &conversion[i].attr;
         }
 
@@ -121,31 +121,31 @@ const attribute_name *convert_attr_name(const wchar_t *name)
 
 static const struct
 {
-    wchar_t base_type;
-    wchar_t *type;
+    char base_type;
+    char *type;
 } base_type_map[9] = {
-    {L'B', L"byte"},
-    {L'C', L"char"},
-    {L'D', L"double"},
-    {L'F', L"float"},
-    {L'I', L"int"},
-    {L'J', L"long"},
-    {L'S', L"short"},
-    {L'Z', L"boolean"},
-    {L'V', L"void"}};
+    {L'B', "byte"},
+    {L'C', "char"},
+    {L'D', "double"},
+    {L'F', "float"},
+    {L'I', "int"},
+    {L'J', "long"},
+    {L'S', "short"},
+    {L'Z', "boolean"},
+    {L'V', "void"}};
 
-wchar_t *parse_descriptor(const wchar_t *descriptor, wchar_t *sep)
+char *parse_descriptor(const char *descriptor, char *sep)
 {
     if (descriptor == NULL)
         return NULL;
 
     unsigned int dim = 0;
-    size_t l = wcslen(descriptor);
+    size_t l = strlen(descriptor);
 
-    wchar_t *buf = (wchar_t *)calloc(256, sizeof(wchar_t));
+    char *buf = (char *)calloc(256, sizeof(char));
 
     if (buf != NULL)
-        for (const wchar_t *desc = descriptor; desc < descriptor + l; desc++)
+        for (const char *desc = descriptor; desc < descriptor + l; desc++)
         {
             if (*desc == L'[')
                 dim++;
@@ -154,13 +154,13 @@ wchar_t *parse_descriptor(const wchar_t *descriptor, wchar_t *sep)
                 switch (*desc)
                 {
                 case L'(':
-                    wcsncat(buf, L"(", 1);
+                    strcat(buf, "(");
                     break;
                 case L')':
-                    wcsncat(buf, L")", 1);
+                    strcat(buf, ")");
                     break;
                 case L'L':
-                    wchar_t *buf_it = buf + wcslen(buf);
+                    char *buf_it = buf + strlen(buf);
                     while (*(++desc) != L';')
                         *(buf_it++) = *desc == L'/' ? L'.' : *desc;
                     *buf_it = L'\0';
@@ -168,13 +168,13 @@ wchar_t *parse_descriptor(const wchar_t *descriptor, wchar_t *sep)
                 default:
                     for (size_t i = 0; i < sizeof(base_type_map) / sizeof(base_type_map[0]); i++)
                         if (*desc == base_type_map[i].base_type)
-                            wcscat(buf, base_type_map[i].type);
+                            strcat(buf, base_type_map[i].type);
                     break;
                 }
 
                 while (dim > 0)
                 {
-                    wcscat(buf, L"[]");
+                    strcat(buf, "[]");
                     dim--;
                 }
 
@@ -185,14 +185,14 @@ wchar_t *parse_descriptor(const wchar_t *descriptor, wchar_t *sep)
                     *(desc + 1) != L')' &&
                     *desc != L'[' &&
                     *desc != L'V')
-                    wcsncat(buf, sep, 1);
+                    strncat(buf, sep, 1);
 
                 // Append whitespace
                 if (desc < descriptor + l &&
                     *desc != L'(' &&
                     *desc != L')' &&
                     *(desc + 1) != L')')
-                    wcsncat(buf, L" ", 1);
+                    strcat(buf, " ");
             }
         }
 

--- a/src/writer.c
+++ b/src/writer.c
@@ -25,17 +25,17 @@ void show_classfile(ClassFile *cf)
     u2 cls_name_index = cp[cf->this_class - 1].info.Class.name_index;
     u2 super_cls_name_index = cp[cf->super_class - 1].info.Class.name_index;
 
-    wchar_t *classname = cp[cls_name_index - 1].info.UTF8.str;
-    wchar_t *super_classname = cp[super_cls_name_index - 1].info.UTF8.str;
+    char *classname = cp[cls_name_index - 1].info.UTF8.str;
+    char *super_classname = cp[super_cls_name_index - 1].info.UTF8.str;
     char *class_access_flags = parse_flags(cf->access_flags, 8, ", ", class_flag_map);
     char *class_kws_flags = parse_flags(cf->access_flags, 6, " ", class_flag_kw_map);
 
-    printf("%s class %ls\n", class_kws_flags, classname);
+    printf("%s class %s\n", class_kws_flags, classname);
     printf("  Magic: %#X\n", cf->magic);
     printf("  Version: %u.%u\n", cf->major_version, cf->minor_version);
     printf("  Flags: (%#.4x) %s\n", cf->access_flags, class_access_flags);
-    printf("  this_class: #%u\t\t\t// %ls\n", cf->this_class, classname);
-    printf("  super_class: #%u\t\t\t// %ls\n", cf->super_class, super_classname);
+    printf("  this_class: #%u\t\t\t// %s\n", cf->this_class, classname);
+    printf("  super_class: #%u\t\t\t// %s\n", cf->super_class, super_classname);
     printf("  interfaces: %u, fields: %u, methods: %u, attributes: %u\n",
            cf->interfaces_count, cf->fields_count, cf->methods_count, cf->attributes_count);
 


### PR DESCRIPTION
Por engano, havia entendido que era necessário um tipo de caractere extendido para melhor compatiblidade com o formato de _string_ da JVM, por isso estava utilizando o tipo `wchar_t` no lugar de `char` para constantes do tipo UTF-8. Realizei a troca e a saída do código ainda é a esperada.