### PR TITLE
Leitura de atributo de Sourcefile

### DIFF
--- a/src/free.c
+++ b/src/free.c
@@ -15,6 +15,9 @@ void free_classfile(ClassFile *cf)
         free_attributes(cp, cf->methods[i].attributes_count, cf->methods[i].attributes);
     free(cf->methods);
 
+    for (size_t i = 0; i < cf->attributes_count; i++)
+        free_attributes(cp, cf->attributes_count, cf->attributes);
+
     for (size_t i = 1; i < (size_t)cf->constant_pool_count - 1; i++)
     {
         if (cp[i].tag == CONSTANT_UTF8)
@@ -41,8 +44,6 @@ void free_attributes(cp_info *cp, u2 count, attribute *attr)
                     free(attr[i].info.Code.exception_table);
                     free_attributes(cp, attr[i].info.Code.attributes_count, attr[i].info.Code.attributes);
                     break;
-                case LineNumberTable:
-                    free(attr[i].info.LineNumberTable.line_number_table);
                 default:
                     break;
                 }

--- a/src/reader.c
+++ b/src/reader.c
@@ -105,6 +105,9 @@ ClassFile read_classfile(FILE *fptr)
             read_member(cf.constant_pool, cf.methods_count, cf.methods, fptr);
 
         cf.attributes_count = read_u2(fptr);
+        cf.attributes = (attribute *)calloc(cf.attributes_count, sizeof(attribute));
+        if (cf.attributes != NULL)
+            read_attributes(cf.constant_pool, cf.attributes_count, fptr, cf.attributes);
     }
 
     printf("%lu bytes readed.\n\n", ftell(fptr));
@@ -190,6 +193,9 @@ void read_attributes(const cp_info *cp, u2 n, FILE *fptr, attribute *attr)
                         if (attr[i].info.Code.attributes != NULL)
                             read_attributes(cp, c, fptr, attr[i].info.Code.attributes);
                     }
+                    break;
+                case SourceFile:
+                    attr[i].info.SourceFile.sourcefile_index = read_u2(fptr);
                     break;
                 default:
                     fseek(fptr, attr[i].attribute_length, SEEK_CUR);


### PR DESCRIPTION
A leitura do atributo `SourceFile` da estrutura `Classfile` foi implementada, incluindo a liberação de memória alocada para os atributos dessa estrutura.