### PR TITLE
Validação de magic number e ajuste de sintaxe

### DIFF
--- a/src/cp/parser.c
+++ b/src/cp/parser.c
@@ -24,16 +24,16 @@ cp_info *parse_constant_pool(FILE *fptr, u2 count)
             cp->info.String.string_index = read_u2(fptr);
             break;
         case CONSTANT_Integer:
-        case CONSTANT_Float:
+        case CONSTANT_Float:{
             u4 ibytes = read_u4(fptr);
             cp->info._4Bn.bytes = ibytes;
             if (cp->tag == CONSTANT_Integer)
                 cp->info._4Bn.number.i = ibytes;
             else
                 cp->info._4Bn.number.f = decode_float_bytes(ibytes);
-            break;
+            break;}
         case CONSTANT_Long:
-        case CONSTANT_Double:
+        case CONSTANT_Double:{
             u4 high_bytes = read_u4(fptr), low_bytes = read_u4(fptr);
             cp->info._8Bn.high_bytes = high_bytes;
             cp->info._8Bn.low_bytes = low_bytes;
@@ -44,12 +44,12 @@ cp_info *parse_constant_pool(FILE *fptr, u2 count)
                 cp->info._8Bn.number.d = decode_double_bytes(high_bytes, low_bytes);
 
             cp++; // Extra increment to account for the extra space for 8 byte constants in the pool table
-            break;
+            break;}
         case CONSTANT_NameAndType:
             cp->info.NameAndType.name_index = read_u2(fptr);
             cp->info.NameAndType.descriptor_index = read_u2(fptr);
             break;
-        case CONSTANT_UTF8:
+        case CONSTANT_UTF8:{
             u2 l = read_u2(fptr);
             cp->info.UTF8.length = l;
 
@@ -64,7 +64,7 @@ cp_info *parse_constant_pool(FILE *fptr, u2 count)
             b -= l;
             cp->info.UTF8.bytes = b;
             cp->info.UTF8.str = decode_modified_utf8_str(l, b);
-            break;
+            break;}
         case CONSTANT_MethodHandle:
             cp->info.MethodHandle.reference_kind = read_u1(fptr);
             cp->info.MethodHandle.reference_index = read_u2(fptr);

--- a/src/cp/writer.c
+++ b/src/cp/writer.c
@@ -14,14 +14,14 @@ void show_constants(u2 count, cp_info *_cp)
         switch (cp->tag)
         {
         case CONSTANT_Class:
-            u2 cls_name_index = cp->info.Class.name_index;
+            {u2 cls_name_index = cp->info.Class.name_index;
             printf("%s#%u = Class\t\t\t#%u\t\t// %s\n",
                    pad, i, cls_name_index, _cp[cls_name_index - 1].info.UTF8.str);
-            break;
+            break;}
         case CONSTANT_Fieldref:
         case CONSTANT_Methodref:
         case CONSTANT_InterfaceMethodref:
-            char *ref;
+            {char *ref;
             if (cp->tag == CONSTANT_Fieldref)
                 ref = "Fieldref";
             else if (cp->tag == CONSTANT_Methodref)
@@ -43,11 +43,11 @@ void show_constants(u2 count, cp_info *_cp)
 
             printf("%s#%u = %s\t\t\t#%u.#%u\t\t// %s.%s:%s\n",
                    pad, i, ref, cls_index, name_and_type_index, cls, ref_name, ref_type);
-            break;
+            break;}
         case CONSTANT_String:
-            u2 str_index = cp->info.String.string_index;
+            {u2 str_index = cp->info.String.string_index;
             printf("%s#%u = String\t\t\t#%u\t\t// %s\n", pad, i, str_index, _cp[str_index - 1].info.UTF8.str);
-            break;
+            break;}
         case CONSTANT_Integer:
             printf("%s#%u = Integer\t\t\t%i\n", pad, i, cp->info._4Bn.number.i);
             break;
@@ -61,7 +61,7 @@ void show_constants(u2 count, cp_info *_cp)
             printf("%s#%u = Double\t\t\t%.1lfd\n", pad, i, cp->info._8Bn.number.d);
             break;
         case CONSTANT_NameAndType:
-            // Índices das strings de nome e descritor
+           { // Índices das strings de nome e descritor
             u2 name_index = cp->info.NameAndType.name_index;
             u2 desc_index = cp->info.NameAndType.descriptor_index;
 
@@ -73,7 +73,7 @@ void show_constants(u2 count, cp_info *_cp)
             name = !strcmp(name, (char *)"<init>") ? "\"<init>\"" : name;
 
             printf("%s#%u = NameAndType\t\t#%u.#%u\t\t// %s:%s\n", pad, i, name_index, desc_index, name, desc);
-            break;
+            break;}
         case CONSTANT_UTF8:
             printf("%s#%u = UTF-8\t\t\t%s\n", pad, i, cp->info.UTF8.str);
             break;

--- a/src/reader.c
+++ b/src/reader.c
@@ -71,6 +71,14 @@ ClassFile read_classfile(FILE *fptr)
         fseek(fptr, 0, SEEK_SET);
 
         cf.magic = read_u4(fptr);
+
+        if (cf.magic != 0xCAFEBABE)
+        {
+            fprintf(stderr, "Erro: arquivo .class inválido (magic number = 0x%08X, esperado 0xCAFEBABE).\n", cf.magic);
+            fclose(fptr);
+            exit(EXIT_FAILURE);
+        }
+        
         cf.minor_version = read_u2(fptr);
         cf.major_version = read_u2(fptr);
         cf.constant_pool_count = read_u2(fptr);

--- a/src/utils.c
+++ b/src/utils.c
@@ -149,11 +149,11 @@ char *parse_descriptor(const char *descriptor, char *sep)
                     strcat(buf, ")");
                     break;
                 case L'L':
-                    char *buf_it = buf + strlen(buf);
+                    {char *buf_it = buf + strlen(buf);
                     while (*(++desc) != L';')
                         *(buf_it++) = *desc == L'/' ? L'.' : *desc;
                     *buf_it = L'\0';
-                    break;
+                    break;}
                 default:
                     for (size_t i = 0; i < sizeof(base_type_map) / sizeof(base_type_map[0]); i++)
                         if (*desc == base_type_map[i].base_type)


### PR DESCRIPTION
Foi implementada a verificação do _magic number_  para garantir que corresponde à `0xCAFEBABE`, como descrito na especificação da JVM 8.
Delimitação de blocos com chaves também foram incluídos para evitar erros de compilação.