### PR TITLE
hotfix: Corrige múltiplos bugs críticos de compilação e execução

### DIFF
--- a/include/cp/parser.h
+++ b/include/cp/parser.h
@@ -5,8 +5,8 @@
 #include <stdlib.h>
 #include <math.h>
 
+#include "types/cp/constants.h"
 #include "reader.h"
-#include "constants.h"
 
 /** @file parser.h
  *  @brief Funções para leitura do _pool_ de constantes e decodificação de _bytes_ de constantes.

--- a/include/cp/writer.h
+++ b/include/cp/writer.h
@@ -5,7 +5,7 @@
 #include <string.h>
 #include <stdio.h>
 
-#include "constants.h"
+#include "types/cp/constants.h"
 #include "uinteger.h"
 #include "utils.h"
 #include "wchar.h"

--- a/include/types/Classfile.h
+++ b/include/types/Classfile.h
@@ -3,7 +3,7 @@
 
 #include "uinteger.h"
 #include "member.h"
-#include "constants.h"
+#include "types/cp/constants.h"
 
 /** @file
  * @brief Definição de estrutura Classfile para representação de um arquivo `.class`.

--- a/include/types/Frame.h
+++ b/include/types/Frame.h
@@ -3,7 +3,7 @@
 
 #include <stdbool.h>
 #include "uinteger.h"
-#include "constants.h"
+#include "types/cp/constants.h"
 #include "Classfile.h"
 #include "MethodArea.h"
 #include "java_type.h"

--- a/src/bootstrap_loader.c
+++ b/src/bootstrap_loader.c
@@ -1,6 +1,7 @@
 #include "bootstrap_loader.h"
+#include <string.h>
 
-static const char *ROOT_FOLDER;
+static char ROOT_FOLDER[2048];
 
 Class *bootstrap_loader(char *path, MethodArea *method_area, const char *class_name)
 {
@@ -14,11 +15,25 @@ Class *bootstrap_loader(char *path, MethodArea *method_area, const char *class_n
             return cls;
 
         // Else, load and parse classfile...
+        if (ROOT_FOLDER[0] == '\0')
+        {
+            fprintf(stderr, "Erro: ROOT_FOLDER não foi inicializado.\n");
+            return NULL;
+        }
 
-        char path[255];
-        snprintf(path, strlen(ROOT_FOLDER) + 1 + strlen(class_name) + 6 + 1, "%s/%s.class", ROOT_FOLDER, class_name);
+        char class_path[2048];
+        int ret = snprintf(class_path, sizeof(class_path), "%s/%s.class", ROOT_FOLDER, class_name);
+        
+        // Check for truncation
+        if (ret < 0 || (size_t)ret >= sizeof(class_path))
+        {
+            fprintf(stderr, "Erro: caminho da classe muito longo.\n");
+            return NULL;
+        }
 
-        cls = create_and_load_class(path);
+        cls = create_and_load_class(class_path);
+        if (cls == NULL)
+            return NULL;
 
         // ...then add to method area
         method_area->classes = (Class *)realloc(method_area->classes, sizeof(Class) * (1 + method_area->num_classes));
@@ -32,21 +47,51 @@ Class *bootstrap_loader(char *path, MethodArea *method_area, const char *class_n
             free(cls);
             return &method_area->classes[i];
         }
+        else
+        {
+            free(cls);
+            return NULL;
+        }
     }
     else // Load initial class
     {
         cls = create_and_load_class(path);
+        if (cls == NULL)
+            return NULL;
 
-        ROOT_FOLDER = strtok(path, "/");
-
-        if (method_area->classes != NULL)
+        // Extract root folder from path (copy before strtok modifies it)
+        char path_copy[2048];
+        strncpy(path_copy, path, sizeof(path_copy) - 1);
+        path_copy[sizeof(path_copy) - 1] = '\0';
+        
+        char *last_slash = strrchr(path_copy, '/');
+        if (last_slash != NULL)
         {
-            method_area->num_classes = 1;
-            method_area->classes[0] = *cls;
-            free(cls);
-            return &method_area->classes[0];
+            *last_slash = '\0';
+            strncpy(ROOT_FOLDER, path_copy, sizeof(ROOT_FOLDER) - 1);
+            ROOT_FOLDER[sizeof(ROOT_FOLDER) - 1] = '\0';
         }
-    }
+        else
+        {
+            // No slash found, use current directory
+            ROOT_FOLDER[0] = '.';
+            ROOT_FOLDER[1] = '\0';
+        }
 
-    return NULL;
+        // Allocate classes array if not already allocated
+        if (method_area->classes == NULL)
+        {
+            method_area->classes = (Class *)malloc(sizeof(Class));
+            if (method_area->classes == NULL)
+            {
+                free(cls);
+                return NULL;
+            }
+        }
+
+        method_area->num_classes = 1;
+        method_area->classes[0] = *cls;
+        free(cls);
+        return &method_area->classes[0];
+    }
 }

--- a/src/bytecode/utils.c
+++ b/src/bytecode/utils.c
@@ -18,28 +18,38 @@ void _print(Frame *f, const char *descriptor, char rettype, char e)
         // TODO: Define logic for class references
         break;
     case 'I':
+    {
         int32_t i = pop_operand(f).value.t._int;
         printf("%i%c", i, e);
         break;
+    }
     case 'J':
+    {
         int64_t l = pop_operand(f).value.t._long;
         printf("%lli%c", l, e);
         break;
+    }
     case 'F':
+    {
         float _f = pop_operand(f).value.t._float;
         printf("%.1f%c", _f, e);
         break;
+    }
     case 'D':
+    {
         double _d = pop_operand(f).value.t._double;
         if (_d == (int64_t)_d)
             printf("%.1f%c", _d, e);
         else
             printf("%.16g%c", _d, e);
         break;
+    }
     case 'C':
+    {
         u2 c = pop_operand(f).value.t._char;
         printf("%c%c", c, e);
         break;
+    }
     // TODO: Define logic for other cases
     default:
         printf("%c", e);

--- a/src/cp/writer.c
+++ b/src/cp/writer.c
@@ -101,6 +101,7 @@ void show_constants(u2 count, cp_info *_cp)
             break;
         }
         case CONSTANT_UTF8:
+        {
             char *str = cp->info.UTF8.str;
 
             str = replace_newlines(str);
@@ -108,6 +109,7 @@ void show_constants(u2 count, cp_info *_cp)
             printf("%s#%u = UTF-8\t\t\t%s\n", pad, i, str);
             free(str);
             break;
+        }
         case CONSTANT_MethodHandle:
             printf("%s#%u = MethodHandle\n", pad, i);
             break;
@@ -173,11 +175,13 @@ char *get_constant_UTF8_value(u2 i, const cp_info *cp)
         break;
     }
     case CONSTANT_String:
+    {
         char *str = get_constant_UTF8_value(cp[i].info.String.string_index, cp);
         s = (char *)malloc((strlen(str) + 1) * sizeof(char));
         strcpy(s, str);
         free(str);
         break;
+    }
     case CONSTANT_Integer:
     case CONSTANT_Float:
     case CONSTANT_Long:

--- a/src/main.c
+++ b/src/main.c
@@ -26,25 +26,35 @@ int main(const int argc, char *argv[])
         MethodArea method_area;
         method_area.num_classes = 0;
         method_area.ref_count = 0;
-        method_area.classes = (Class *)malloc(sizeof(Class));
-        if (method_area.classes == NULL)
-            exit(1);
+        method_area.classes = NULL;
+        method_area.refs = NULL;
 
         // Load and link input class as initial class
         Class *initial_class = bootstrap_loader(argv[2], &method_area, NULL);
-        if (initial_class != NULL)
+        if (initial_class == NULL)
         {
-            // Invoke main method
-            Method *main_method = lookup_method("main", "([Ljava/lang/String;)V", initial_class);
-            if (!main_method)
-            {
-                printf("Método \"main\" não encontrado.\n");
-                exit(1);
-            }
-
-            dtype *local_vars = (dtype *)calloc(main_method->bytecode.max_locals, sizeof(dtype));
-            invoke_method(initial_class, main_method, local_vars, NULL, &method_area);
+            fprintf(stderr, "Erro: não foi possível carregar a classe '%s'.\n", argv[2]);
+            cleanup(method_area);
+            return 1;
         }
+
+        // Invoke main method
+        Method *main_method = lookup_method("main", "([Ljava/lang/String;)V", initial_class);
+        if (!main_method)
+        {
+            printf("Método \"main\" não encontrado.\n");
+            cleanup(method_area);
+            return 1;
+        }
+
+        dtype *local_vars = (dtype *)calloc(main_method->bytecode.max_locals, sizeof(dtype));
+        if (local_vars == NULL)
+        {
+            fprintf(stderr, "Erro: falha ao alocar memória para variáveis locais.\n");
+            cleanup(method_area);
+            return 1;
+        }
+        invoke_method(initial_class, main_method, local_vars, NULL, &method_area);
 
         // Clean method area
         cleanup(method_area);
@@ -59,6 +69,11 @@ int main(const int argc, char *argv[])
             ClassFile cf = read_classfile(fptr, true);
             show_classfile(&cf);
             free_classfile(&cf);
+        }
+        else
+        {
+            fprintf(stderr, "Erro: não foi possível abrir o arquivo '%s'.\n", argv[2]);
+            return 1;
         }
     }
     else

--- a/src/method_area_utils.c
+++ b/src/method_area_utils.c
@@ -155,6 +155,11 @@ Class *create_and_load_class(const char *path)
 {
     // Open and parse classfile
     FILE *fptr = open_classfile(path);
+    if (fptr == NULL)
+    {
+        // open_classfile already prints error message
+        return NULL;
+    }
     ClassFile cf = read_classfile(fptr, false);
 
     // Create class
@@ -175,40 +180,73 @@ Class *create_and_load_class(const char *path)
 
 void cleanup(MethodArea method_area)
 {
-    for (size_t i = 0; i < method_area.ref_count; i++)
-        free(method_area.refs[i]);
-    free(method_area.refs);
-
-    for (size_t i = 0; i < method_area.num_classes; i++)
+    // Clean up references
+    if (method_area.refs != NULL)
     {
-        Class cls = method_area.classes[i];
-        free(cls.name);
-        free(cls.super);
-
-        for (size_t j = 0; j < cls.constants_count; j++)
+        for (size_t i = 0; i < method_area.ref_count; i++)
         {
-            if ((cls.runtime_cp[j].type >= 7 && cls.runtime_cp[j].type <= 11) ||
-                cls.runtime_cp[j].type >= 15)
-                free(cls.runtime_cp[j].value.strref);
+            if (method_area.refs[i] != NULL)
+                free(method_area.refs[i]);
         }
-        free(cls.runtime_cp);
-
-        for (u2 j = 0; j < cls.field_count; j++)
-        {
-            free(cls.fields[j].name);
-            free(cls.fields[j].type);
-        }
-        free(cls.fields);
-
-        for (u2 j = 0; j < cls.method_count; j++)
-        {
-            free(cls.methods[j].name);
-            free(cls.methods[j].descriptor);
-            free(cls.methods[j].params);
-            free(cls.methods[j].rettype);
-            free(cls.methods[j].bytecode.code);
-        }
-        free(method_area.classes[i].methods);
+        free(method_area.refs);
     }
-    free(method_area.classes);
+
+    // Clean up classes
+    if (method_area.classes != NULL)
+    {
+        for (size_t i = 0; i < method_area.num_classes; i++)
+        {
+            Class cls = method_area.classes[i];
+            
+            if (cls.name != NULL)
+                free(cls.name);
+            if (cls.super != NULL)
+                free(cls.super);
+
+            if (cls.runtime_cp != NULL)
+            {
+                for (size_t j = 0; j < cls.constants_count; j++)
+                {
+                    if ((cls.runtime_cp[j].type >= 7 && cls.runtime_cp[j].type <= 11) ||
+                        cls.runtime_cp[j].type >= 15)
+                    {
+                        if (cls.runtime_cp[j].value.strref != NULL)
+                            free(cls.runtime_cp[j].value.strref);
+                    }
+                }
+                free(cls.runtime_cp);
+            }
+
+            if (cls.fields != NULL)
+            {
+                for (u2 j = 0; j < cls.field_count; j++)
+                {
+                    if (cls.fields[j].name != NULL)
+                        free(cls.fields[j].name);
+                    if (cls.fields[j].type != NULL)
+                        free(cls.fields[j].type);
+                }
+                free(cls.fields);
+            }
+
+            if (cls.methods != NULL)
+            {
+                for (u2 j = 0; j < cls.method_count; j++)
+                {
+                    if (cls.methods[j].name != NULL)
+                        free(cls.methods[j].name);
+                    if (cls.methods[j].descriptor != NULL)
+                        free(cls.methods[j].descriptor);
+                    if (cls.methods[j].params != NULL)
+                        free(cls.methods[j].params);
+                    if (cls.methods[j].rettype != NULL)
+                        free(cls.methods[j].rettype);
+                    if (cls.methods[j].bytecode.code != NULL)
+                        free(cls.methods[j].bytecode.code);
+                }
+                free(cls.methods);
+            }
+        }
+        free(method_area.classes);
+    }
 }

--- a/src/reader.c
+++ b/src/reader.c
@@ -1,4 +1,5 @@
 #include "reader.h"
+#include <errno.h>
 
 /** @file
  * @brief Definições de funções relacionadas a leitura de arquivos `.class`.
@@ -48,14 +49,25 @@ FILE *open_classfile(const char *path)
 
         if (strcmp(ext, ".class") != 0)
         {
-            printf("Wrong file format. Give the path of a \".class\" file.\n");
-            exit(1);
+            fprintf(stderr, "Erro: formato de arquivo inválido. Forneça o caminho de um arquivo \".class\".\n");
+            return NULL;
         }
 
-        return fopen(path, "rb");
+        FILE *fptr = fopen(path, "rb");
+        if (fptr == NULL)
+        {
+            fprintf(stderr, "Erro: não foi possível abrir o arquivo '%s'. ", path);
+            if (errno == ENOENT)
+                fprintf(stderr, "Arquivo não encontrado.\n");
+            else if (errno == EACCES)
+                fprintf(stderr, "Permissão negada.\n");
+            else
+                fprintf(stderr, "Erro: %s\n", strerror(errno));
+        }
+        return fptr;
     }
 
-    printf("Invalid path.\n");
+    fprintf(stderr, "Erro: caminho inválido.\n");
     return NULL;
 }
 
@@ -240,6 +252,7 @@ void read_attributes(const cp_info *cp, u2 n, FILE *fptr, attribute *attr)
                     break;
                 }
                 case InnerClasses:
+                {
                     u2 n = read_u2(fptr);
 
                     attr[i].info.InnerClasses.number_of_classes = n;
@@ -260,6 +273,7 @@ void read_attributes(const cp_info *cp, u2 n, FILE *fptr, attribute *attr)
                         }
                     }
                     break;
+                }
                 default:
                     fseek(fptr, attr[i].attribute_length, SEEK_CUR);
                     break;

--- a/src/writer.c
+++ b/src/writer.c
@@ -51,6 +51,7 @@ static void show_class_attributes(ClassFile *cf)
             switch (*attr_enum)
             {
             case SourceFile:
+            {
                 u2 sourcefile_index = ai->info.SourceFile.sourcefile_index; // já vem parseado
                 if (sourcefile_index > 0 && sourcefile_index <= cf->constant_pool_count)
                 {
@@ -65,7 +66,9 @@ static void show_class_attributes(ClassFile *cf)
                     printf("SourceFile: <invalid cp index #%u>\n", sourcefile_index);
                 }
                 break;
+            }
             case InnerClasses:
+            {
                 u2 n = ai->info.InnerClasses.number_of_classes;
                 if (n > 0)
                 {
@@ -83,6 +86,7 @@ static void show_class_attributes(ClassFile *cf)
                     }
                 }
                 break;
+            }
             default:
                 printf("[%s: length=%u]\n", attr_name, ai->attribute_length);
                 break;


### PR DESCRIPTION
Principais bugs corrigidos:

1. Erros de compilação - Tipos desconhecidos (cp_info, ClassFile)
   - Corrigidos includes incorretos de 'constants.h' para 'types/cp/constants.h'
   - Arquivos afetados: cp/parser.h, cp/writer.h, types/Classfile.h, types/Frame.h
   - Reordenada ordem de includes em cp/parser.h para evitar dependências circulares

2. Erros de compilação - Declarações em cases do switch
   - Adicionadas chaves {} em todos os cases que contêm declarações de variáveis
   - Arquivos afetados: writer.c, bytecode/utils.c, reader.c, cp/writer.c
   - Resolve erro: 'a label can only be part of a statement'

3. Segmentation fault no modo --execute
   - Adicionadas verificações de NULL em create_and_load_class
   - Corrigida inicialização do method_area em main.c
   - Corrigida alocação de classes em bootstrap_loader quando necessário
   - Adicionado tratamento de erro quando bootstrap_loader retorna NULL

4. Erro de memória (munmap_chunk: invalid pointer)
   - Corrigida função cleanup() com verificações de NULL antes de free()
   - Adicionadas verificações para todos os ponteiros antes de liberação
   - Previne tentativa de liberar memória inválida

5. Mensagens de erro duplicadas
   - Removida mensagem duplicada em create_and_load_class
   - open_classfile agora imprime mensagens de erro mais detalhadas
   - Adicionado suporte para errno com mensagens específicas

6. Melhorias gerais
   - Adicionado tratamento de truncamento em snprintf em bootstrap_loader
   - Melhoradas mensagens de erro com informações mais específicas
   - Adicionado include de errno.h em reader.c